### PR TITLE
DEP: fix missing dependency on `exceptiongroup` for v0.3.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 779bffc3e3ab7059255a48ebf998f10b78f47c23a42d36dbb1fa4a66e149d7af
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -29,6 +29,7 @@ requirements:
   run:
     - python
     - numpy >=1.21.0
+    - exceptiongroup >=1.0.0  # [py<311]
 
 test:
   source_files:


### PR DESCRIPTION
Looks like this wasn't caught during the first build because `exceptiongroup` was still installed into the test env (supposedly because pytest itself requires it on Python 3.10).

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
